### PR TITLE
temporaly delete scroll trigger

### DIFF
--- a/ad.js
+++ b/ad.js
@@ -4,22 +4,6 @@ $(document).ready(function () {
 		width : ^box_width,
 		height: ^box_height
 	});
-	percentage = ^percentage;
-	popupflg = false;
-	if (percentage <= 0) {
-		popup.open('^html', 'html');
-		popupflg = true;
-	}
-	$(^window).scroll(function (e) {
-		var window = $(e.currentTarget),
-		scrollTop = window.scrollTop(),
-		documentHeight = $(document).height();
-		scrollHeight = documentHeight * (percentage / 100)
-
-		if ( !popupflg && scrollHeight <= scrollTop) {
-			popup.open('^html', 'html');
-			popupflg = true;
-		}
-	});
+	popup.open('^html', 'html');
 });
 </script>

--- a/qa-popup-ad-layer.php
+++ b/qa-popup-ad-layer.php
@@ -28,13 +28,13 @@ class qa_html_theme_layer extends qa_html_theme_base
 		$js = file_get_contents(POPAD_DIR . '/ad.js');
 		$html = file_get_contents(POPAD_DIR . '/ad.html');
 		$html = str_replace(PHP_EOL, '', $html);
-		$percentage = qa_opt('qa_popup_ad_scroll_percentage');
+//		$percentage = qa_opt('qa_popup_ad_scroll_percentage');
 		$params = array(
 			'^html' => $html,
 			'^box_width' => '700',
 			'^box_height' => '430',
-			'^percentage' => (!empty($percentage) ? (int)$percentage : 0),
-			'^window' => '".mdl-layout__content"',
+//			'^percentage' => (!empty($percentage) ? (int)$percentage : 0),
+//			'^window' => '".mdl-layout__content"',
 		);
 		$js = strtr($js, $params);
 		$this->output($js);


### PR DESCRIPTION
https://github.com/yshiga/bee-qa/issues/765 対応
スクロール量を計測する時にpopup-adのイベントハンドラが邪魔になるので一時的に削除